### PR TITLE
Make initializer optional

### DIFF
--- a/lib/Genie/src/bootstrap.jl
+++ b/lib/Genie/src/bootstrap.jl
@@ -65,9 +65,12 @@ end
 
 function load_initializers()
   dir = abspath(joinpath(Genie.APP_PATH, "config", "initializers"))
-  f = readdir(dir)
-  for i in f
-    include(joinpath(dir, i))
+
+  if isdir(dir)
+    f = readdir(dir)
+    for i in f
+      include(joinpath(dir, i))
+    end
   end
 end
 


### PR DESCRIPTION
Just a small fix (I think); an error was being thrown if no initializer directory existed. As the docs imply this is optional, I assume the code is supposed to enforce/support this.