### PR TITLE
CORS Headers for API Apps

### DIFF
--- a/files/new_app/config/app.jl
+++ b/files/new_app/config/app.jl
@@ -1,4 +1,9 @@
 # Place here configuration options that will be set for all environments
 if isdefined(:config)
   config.app_is_api = false
+  config.cors_headers = Dict{String,String}(
+      "Access-Control-Allow-Origin"  => "*",
+      "Access-Control-Allow-Methods" => "GET, POST, PATCH, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers" => "Origin, Content-Type, X-Auth-Token",
+    )
 end

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -135,6 +135,9 @@ function handle_request(req::Request, res::Response, ip::IPv4 = ip"0.0.0.0") :: 
   App.config.server_signature != "" && sign_response!(res)
 
   app_response::Response = Router.route_request(req, res, ip)
+  if(App.config.app_is_api)
+    app_response.headers = merge(res.headers, App.config.cors_headers)
+  end
   app_response.headers = merge(res.headers, app_response.headers)
   app_response.cookies = merge(res.cookies, app_response.cookies)
 

--- a/src/configuration.jl
+++ b/src/configuration.jl
@@ -79,6 +79,7 @@ mutable struct Settings
 
   app_env::String
   app_is_api::Bool
+  cors_headers::Dict{String,String}
 
   suppress_output::Bool
   output_length::Int
@@ -147,6 +148,7 @@ mutable struct Settings
 
             app_env       = ENV["GENIE_ENV"],
             app_is_api    = true,
+            cors_headers  = Dict{String,String}(),
 
             suppress_output = false,
             output_length   = 10_000, # where to truncate strings in console
@@ -208,7 +210,7 @@ mutable struct Settings
         ) =
               new(
                   server_port, server_workers_count, server_document_root, server_handle_static_files, server_signature,
-                  app_env, app_is_api,
+                  app_env, app_is_api, cors_headers,
                   suppress_output, output_length,
                   db_migrations_table_name, db_migrations_folder, db_config_settings,
                   task_folder, test_folder,


### PR DESCRIPTION
Headers can be defined via config and are only added when `app_is_api`.
Global routing to method type `OPTIONS` for api calls responds with a 200, cors headers, and simple message.

Set CORS headers in config files by setting `config.cors_headers` to a Dict{String,String} containing desired headers. By default this is empty.