### PR TITLE
fix searchindex -> findfirst function

### DIFF
--- a/src/Input.jl
+++ b/src/Input.jl
@@ -80,7 +80,7 @@ end
 
 function post_multipart!(request::HTTP.Request, post_data::HttpPostData, files::HttpFiles)
   headers = Dict(request.headers)
-  boundary::String = headers["Content-Type"][(searchindex(request.headers["Content-Type"], "boundary=") + 9):end]
+  boundary::String = headers["Content-Type"][(findfirst("boundary=", headers["Content-Type"])[end] + 1):end]
 
   boundary_length::Int = length(boundary)
 


### PR DESCRIPTION
searchindex function isn't defined in julia v1.0 .
So I change searchindex to findfirst
This fix was done other code in Genie.

```
julia> headers = Dict(SubString("Content-Type") => SubString("testboundary=example"))
Dict{SubString{String},SubString{String}} with 1 entry:
  "Content-Type" => "testboundary=example"

julia> headers["Content-Type"][(findfirst("boundary=", headers["Content-Type"])[end] + 1):end]
"example"
```